### PR TITLE
feat: Add essential CLI enhancements (--version and --quiet flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ mvn-tree-visualizer --filename "maven_dependency_file" --output "dependencies.js
 mvn-tree-visualizer --filename "maven_dependency_file" --output "diagram.html" --watch
 ```
 
+#### Quiet Mode (For Automation/Scripts)
+```bash
+# Only show errors, suppress success messages
+mvn-tree-visualizer --filename "maven_dependency_file" --output "diagram.html" --quiet
+
+# Short form also available
+mvn-tree-visualizer --filename "maven_dependency_file" --output "diagram.html" -q
+```
+
 > **💡 Tip:** In watch mode, the tool will monitor for changes to your Maven dependency files and automatically regenerate the diagram. Perfect for development workflows! Press `Ctrl+C` to stop watching.
 
 ### Step 3: View the output
@@ -123,6 +132,7 @@ Each example includes:
 | `--watch` | Watch for file changes and auto-regenerate diagram | `False` |
 | `--directory` | The directory to scan for the Maven dependency file(s) | current directory |
 | `--keep-tree` | Keep the intermediate `dependency_tree.txt` file | `False` |
+| `--quiet`, `-q` | Suppress all console output except errors | `False` |
 | `--version`, `-v` | Show the current version and exit | - |
 | `--help` | Show the help message and exit | - |
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Each example includes:
 | `--watch` | Watch for file changes and auto-regenerate diagram | `False` |
 | `--directory` | The directory to scan for the Maven dependency file(s) | current directory |
 | `--keep-tree` | Keep the intermediate `dependency_tree.txt` file | `False` |
+| `--version`, `-v` | Show the current version and exit | - |
 | `--help` | Show the help message and exit | - |
 
 ### Theme Options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "build>=1.0.0",
     "git-changelog>=2.5.3",
     "tox>=4.28.4",
+    "pytest>=8.4.1",
 ]
 
 [build-system]

--- a/src/mvn_tree_visualizer/cli.py
+++ b/src/mvn_tree_visualizer/cli.py
@@ -240,9 +240,10 @@ def cli() -> NoReturn:
     except Exception:
         sys.exit(1)
 
-    if not watch_mode and not quiet:
-        print("You can open it in your browser to view the dependency tree.")
-        print("Thank you for using mvn-tree-visualizer!")
+    if not watch_mode:
+        if not quiet:
+            print("You can open it in your browser to view the dependency tree.")
+            print("Thank you for using mvn-tree-visualizer!")
         return
 
     # Watch mode

--- a/src/mvn_tree_visualizer/cli.py
+++ b/src/mvn_tree_visualizer/cli.py
@@ -250,9 +250,10 @@ def cli() -> NoReturn:
         """Callback function for file watcher."""
         try:
             generate_diagram(directory, output_file, filename, keep_tree, output_format, show_versions, theme, quiet)
-        except Exception:
+        except Exception as e:
             # In watch mode, we don't want to exit on errors, just log them
-            pass
+            print("Error during diagram regeneration:", file=sys.stderr)
+            traceback.print_exc()
 
     watcher = FileWatcher(directory, filename, regenerate_callback)
     watcher.start()

--- a/src/mvn_tree_visualizer/cli.py
+++ b/src/mvn_tree_visualizer/cli.py
@@ -229,7 +229,8 @@ def cli() -> NoReturn:
 
     # Generate initial diagram
     if not quiet:
-        print("Generating initial diagram...")
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        print(f"[{timestamp}] Generating initial diagram...")
 
     try:
         generate_diagram(directory, output_file, filename, keep_tree, output_format, show_versions, theme, quiet)

--- a/src/mvn_tree_visualizer/cli.py
+++ b/src/mvn_tree_visualizer/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import time
+from importlib import metadata
 from pathlib import Path
 from typing import NoReturn
 
@@ -10,6 +11,14 @@ from .get_dependencies_in_one_file import merge_files
 from .outputs.html_output import create_html_diagram
 from .outputs.json_output import create_json_output
 from .validation import find_dependency_files, validate_dependency_files, validate_output_directory
+
+
+def get_version() -> str:
+    """Get the current version of the package."""
+    try:
+        return metadata.version("mvn-tree-visualizer")
+    except metadata.PackageNotFoundError:
+        return "unknown"
 
 
 def generate_diagram(
@@ -128,6 +137,14 @@ def cli() -> NoReturn:
         prog="mvn-tree-visualizer",
         description="Generate a dependency diagram from a file.",
     )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"mvn-tree-visualizer {get_version()}",
+    )
+
     parser.add_argument(
         "directory",
         type=str,

--- a/src/mvn_tree_visualizer/cli.py
+++ b/src/mvn_tree_visualizer/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 import time
 from importlib import metadata
 from pathlib import Path
@@ -29,6 +30,7 @@ def generate_diagram(
     output_format: str,
     show_versions: bool,
     theme: str = "minimal",
+    quiet: bool = False,
 ) -> None:
     """Generate the dependency diagram with comprehensive error handling."""
     timestamp = time.strftime("%H:%M:%S")
@@ -40,7 +42,7 @@ def generate_diagram(
 
         # Show what files we found
         dependency_files = find_dependency_files(directory, filename)
-        if len(dependency_files) > 1:
+        if len(dependency_files) > 1 and not quiet:
             print(f"[{timestamp}] Found {len(dependency_files)} dependency files")
 
         # Setup paths
@@ -112,24 +114,28 @@ def generate_diagram(
         except Exception as e:
             raise OutputGenerationError(f"Error generating {output_format.upper()} output: {e}")
 
-        print(f"[{timestamp}] ✅ Diagram generated and saved to {output_file}")
+        if not quiet:
+            print(f"[{timestamp}] SUCCESS: Diagram generated and saved to {output_file}")
 
     except MvnTreeVisualizerError as e:
         # Our custom errors already have helpful messages
-        print(f"[{timestamp}] ❌ Error: {e}")
+        print(f"[{timestamp}] ERROR: {e}", file=sys.stderr)
+        raise  # Re-raise the exception for the caller to handle
     except KeyboardInterrupt:
-        print(f"\n[{timestamp}] ⏹️  Operation cancelled by user")
+        print(f"\n[{timestamp}] Operation cancelled by user", file=sys.stderr)
+        raise  # Re-raise for the caller to handle
     except Exception as e:
         # Unexpected errors
-        print(f"[{timestamp}] ❌ Unexpected error: {e}")
-        print("This is an internal error. Please report this issue with the following details:")
-        print(f"  - Directory: {directory}")
-        print(f"  - Filename: {filename}")
-        print(f"  - Output: {output_file}")
-        print(f"  - Format: {output_format}")
+        print(f"[{timestamp}] UNEXPECTED ERROR: {e}", file=sys.stderr)
+        print("This is an internal error. Please report this issue with the following details:", file=sys.stderr)
+        print(f"  - Directory: {directory}", file=sys.stderr)
+        print(f"  - Filename: {filename}", file=sys.stderr)
+        print(f"  - Output: {output_file}", file=sys.stderr)
+        print(f"  - Format: {output_format}", file=sys.stderr)
         import traceback
 
         traceback.print_exc()
+        raise  # Re-raise for the caller to handle
 
 
 def cli() -> NoReturn:
@@ -203,6 +209,13 @@ def cli() -> NoReturn:
         help="Theme for the diagram visualization. Default is 'minimal'.",
     )
 
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress all console output except errors. Perfect for CI/CD pipelines and scripted usage.",
+    )
+
     args = parser.parse_args()
     directory: str = args.directory
     output_file: str = args.output
@@ -212,12 +225,22 @@ def cli() -> NoReturn:
     show_versions: bool = args.show_versions
     watch_mode: bool = args.watch
     theme: str = args.theme
+    quiet: bool = args.quiet
 
     # Generate initial diagram
-    print("Generating initial diagram...")
-    generate_diagram(directory, output_file, filename, keep_tree, output_format, show_versions, theme)
+    if not quiet:
+        print("Generating initial diagram...")
 
-    if not watch_mode:
+    try:
+        generate_diagram(directory, output_file, filename, keep_tree, output_format, show_versions, theme, quiet)
+    except MvnTreeVisualizerError:
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)  # Standard exit code for SIGINT
+    except Exception:
+        sys.exit(1)
+
+    if not watch_mode and not quiet:
         print("You can open it in your browser to view the dependency tree.")
         print("Thank you for using mvn-tree-visualizer!")
         return
@@ -225,7 +248,11 @@ def cli() -> NoReturn:
     # Watch mode
     def regenerate_callback():
         """Callback function for file watcher."""
-        generate_diagram(directory, output_file, filename, keep_tree, output_format, show_versions, theme)
+        try:
+            generate_diagram(directory, output_file, filename, keep_tree, output_format, show_versions, theme, quiet)
+        except Exception:
+            # In watch mode, we don't want to exit on errors, just log them
+            pass
 
     watcher = FileWatcher(directory, filename, regenerate_callback)
     watcher.start()
@@ -233,7 +260,8 @@ def cli() -> NoReturn:
     try:
         watcher.wait()
     finally:
-        print("Thank you for using mvn-tree-visualizer!")
+        if not quiet:
+            print("Thank you for using mvn-tree-visualizer!")
 
 
 if __name__ == "__main__":

--- a/src/mvn_tree_visualizer/cli.py
+++ b/src/mvn_tree_visualizer/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 import time
+import traceback
 from importlib import metadata
 from pathlib import Path
 from typing import NoReturn
@@ -132,7 +133,6 @@ def generate_diagram(
         print(f"  - Filename: {filename}", file=sys.stderr)
         print(f"  - Output: {output_file}", file=sys.stderr)
         print(f"  - Format: {output_format}", file=sys.stderr)
-        import traceback
 
         traceback.print_exc()
         raise  # Re-raise for the caller to handle
@@ -250,7 +250,7 @@ def cli() -> NoReturn:
         """Callback function for file watcher."""
         try:
             generate_diagram(directory, output_file, filename, keep_tree, output_format, show_versions, theme, quiet)
-        except Exception as e:
+        except Exception:
             # In watch mode, we don't want to exit on errors, just log them
             print("Error during diagram regeneration:", file=sys.stderr)
             traceback.print_exc()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@
 
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -61,7 +63,7 @@ class TestVersionFlag:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=8,
                 cwd=".",
             )
 
@@ -91,7 +93,7 @@ class TestVersionFlag:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=8,
                 cwd=".",
             )
 
@@ -122,7 +124,7 @@ class TestVersionFlag:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=8,
                 cwd=".",
             )
 
@@ -147,7 +149,7 @@ class TestVersionFlag:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=8,
                 cwd=".",
             )
 
@@ -172,97 +174,121 @@ class TestQuietFlag:
 
     def test_quiet_flag_long_form(self):
         """Test --quiet flag suppresses output."""
-        try:
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "mvn_tree_visualizer",
-                    "examples/simple-project",
-                    "--quiet",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                cwd=".",
-            )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_output = Path(temp_dir) / "test_diagram.html"
 
-            # Should exit with code 0 (success)
-            assert result.returncode == 0
+            try:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "mvn_tree_visualizer",
+                        "examples/simple-project",
+                        "--quiet",
+                        "--output",
+                        str(temp_output),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=8,
+                    cwd=".",
+                )
 
-            # Should have no stdout output when quiet
-            assert result.stdout.strip() == ""
+                # Should exit with code 0 (success)
+                assert result.returncode == 0
 
-            # Should not have stderr output for normal operation
-            assert result.stderr == ""
+                # Should have no stdout output when quiet
+                assert result.stdout.strip() == ""
 
-        except subprocess.TimeoutExpired:
-            pytest.fail("--quiet command timed out")
-        except FileNotFoundError:
-            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+                # Should not have stderr output for normal operation
+                assert result.stderr == ""
+
+                # Should have created the output file
+                assert temp_output.exists()
+
+            except subprocess.TimeoutExpired:
+                pytest.fail("--quiet command timed out")
+            except FileNotFoundError:
+                pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
 
     def test_quiet_flag_short_form(self):
         """Test -q flag suppresses output."""
-        try:
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "mvn_tree_visualizer",
-                    "examples/simple-project",
-                    "-q",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                cwd=".",
-            )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_output = Path(temp_dir) / "test_diagram.html"
 
-            # Should exit with code 0 (success)
-            assert result.returncode == 0
+            try:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "mvn_tree_visualizer",
+                        "examples/simple-project",
+                        "-q",
+                        "--output",
+                        str(temp_output),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=8,
+                    cwd=".",
+                )
 
-            # Should have no stdout output when quiet
-            assert result.stdout.strip() == ""
+                # Should exit with code 0 (success)
+                assert result.returncode == 0
 
-            # Should not have stderr output for normal operation
-            assert result.stderr == ""
+                # Should have no stdout output when quiet
+                assert result.stdout.strip() == ""
 
-        except subprocess.TimeoutExpired:
-            pytest.fail("-q command timed out")
-        except FileNotFoundError:
-            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+                # Should not have stderr output for normal operation
+                assert result.stderr == ""
+
+                # Should have created the output file
+                assert temp_output.exists()
+
+            except subprocess.TimeoutExpired:
+                pytest.fail("-q command timed out")
+            except FileNotFoundError:
+                pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
 
     def test_normal_output_without_quiet(self):
         """Test that normal output works when --quiet is not used."""
-        try:
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "mvn_tree_visualizer",
-                    "examples/simple-project",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                cwd=".",
-            )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_output = Path(temp_dir) / "test_diagram.html"
 
-            # Should exit with code 0 (success)
-            assert result.returncode == 0
+            try:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "mvn_tree_visualizer",
+                        "examples/simple-project",
+                        "--output",
+                        str(temp_output),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=8,
+                    cwd=".",
+                )
 
-            # Should have stdout output when not quiet
-            assert len(result.stdout.strip()) > 0
-            assert "Generating initial diagram..." in result.stdout
-            assert "Diagram generated and saved" in result.stdout
+                # Should exit with code 0 (success)
+                assert result.returncode == 0
 
-            # Should not have stderr output for normal operation
-            assert result.stderr == ""
+                # Should have stdout output when not quiet
+                assert len(result.stdout.strip()) > 0
+                assert "Generating initial diagram..." in result.stdout
+                assert "Diagram generated and saved" in result.stdout
 
-        except subprocess.TimeoutExpired:
-            pytest.fail("normal output command timed out")
-        except FileNotFoundError:
-            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+                # Should not have stderr output for normal operation
+                assert result.stderr == ""
+
+                # Should have created the output file
+                assert temp_output.exists()
+
+            except subprocess.TimeoutExpired:
+                pytest.fail("normal output command timed out")
+            except FileNotFoundError:
+                pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
 
     def test_quiet_flag_still_shows_errors(self):
         """Test that --quiet still shows errors on stderr."""
@@ -277,7 +303,7 @@ class TestQuietFlag:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=8,
                 cwd=".",
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,167 @@
+"""Tests for CLI functionality."""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from mvn_tree_visualizer.cli import get_version
+
+
+class TestVersionFlag:
+    """Test the --version/-v flag functionality."""
+
+    def test_get_version_function_returns_string(self):
+        """Test that get_version() returns a valid version string."""
+        version = get_version()
+        assert isinstance(version, str)
+        assert len(version) > 0
+        # Should either be a proper version (like "1.6.0") or "unknown"
+        assert (
+            version == "unknown"
+            or version.replace(".", "")
+            .replace("-", "")
+            .replace("+", "")
+            .replace("dev", "")
+            .replace("rc", "")
+            .replace("a", "")
+            .replace("b", "")
+            .isalnum()
+        )
+
+    @patch("mvn_tree_visualizer.cli.metadata.version")
+    def test_get_version_handles_package_not_found(self, mock_version):
+        """Test that get_version() handles PackageNotFoundError gracefully."""
+        from importlib.metadata import PackageNotFoundError
+
+        mock_version.side_effect = PackageNotFoundError("Package not found")
+
+        version = get_version()
+        assert version == "unknown"
+
+    @patch("mvn_tree_visualizer.cli.metadata.version")
+    def test_get_version_returns_correct_version(self, mock_version):
+        """Test that get_version() returns the mocked version."""
+        mock_version.return_value = "1.6.0"
+
+        version = get_version()
+        assert version == "1.6.0"
+        mock_version.assert_called_once_with("mvn-tree-visualizer")
+
+    def test_version_flag_long_form(self):
+        """Test --version flag via subprocess."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "--version",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=".",
+            )
+
+            # Should exit with code 0 (success)
+            assert result.returncode == 0
+
+            # Should output version information
+            assert "mvn-tree-visualizer" in result.stdout
+
+            # Should not have stderr output for normal version display
+            assert result.stderr == ""
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("--version command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+
+    def test_version_flag_short_form(self):
+        """Test -v flag via subprocess."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "-v",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=".",
+            )
+
+            # Should exit with code 0 (success)
+            assert result.returncode == 0
+
+            # Should output version information
+            assert "mvn-tree-visualizer" in result.stdout
+
+            # Should not have stderr output for normal version display
+            assert result.stderr == ""
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("-v command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+
+    def test_version_flag_takes_precedence(self):
+        """Test that --version flag takes precedence over other arguments."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "--version",
+                    "some_directory",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=".",
+            )
+
+            # Should still exit with code 0 and show version
+            assert result.returncode == 0
+            assert "mvn-tree-visualizer" in result.stdout
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("--version with extra args command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+
+    def test_version_output_format(self):
+        """Test that version output follows expected format."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "--version",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=".",
+            )
+
+            if result.returncode == 0:
+                # Should be in format "mvn-tree-visualizer X.Y.Z"
+                output = result.stdout.strip()
+                parts = output.split()
+                assert len(parts) == 2
+                assert parts[0] == "mvn-tree-visualizer"
+                # Second part should be version number
+                version_part = parts[1]
+                assert len(version_part) > 0
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("--version format test command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,14 @@ import pytest
 from mvn_tree_visualizer.cli import get_version
 
 
+def is_valid_version_string(version: str) -> bool:
+    """Check if the version string is valid."""
+    return (
+        version == "unknown"
+        or version.replace(".", "").replace("-", "").replace("+", "").replace("dev", "").replace("rc", "").replace("a", "").replace("b", "").isalnum()
+    )
+
+
 class TestVersionFlag:
     """Test the --version/-v flag functionality."""
 
@@ -20,17 +28,8 @@ class TestVersionFlag:
         assert isinstance(version, str)
         assert len(version) > 0
         # Should either be a proper version (like "1.6.0") or "unknown"
-        assert (
-            version == "unknown"
-            or version.replace(".", "")
-            .replace("-", "")
-            .replace("+", "")
-            .replace("dev", "")
-            .replace("rc", "")
-            .replace("a", "")
-            .replace("b", "")
-            .isalnum()
-        )
+
+        assert is_valid_version_string(version)
 
     @patch("mvn_tree_visualizer.cli.metadata.version")
     def test_get_version_handles_package_not_found(self, mock_version):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,3 +165,133 @@ class TestVersionFlag:
             pytest.fail("--version format test command timed out")
         except FileNotFoundError:
             pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+
+
+class TestQuietFlag:
+    """Test the --quiet/-q flag functionality."""
+
+    def test_quiet_flag_long_form(self):
+        """Test --quiet flag suppresses output."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "examples/simple-project",
+                    "--quiet",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=".",
+            )
+
+            # Should exit with code 0 (success)
+            assert result.returncode == 0
+
+            # Should have no stdout output when quiet
+            assert result.stdout.strip() == ""
+
+            # Should not have stderr output for normal operation
+            assert result.stderr == ""
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("--quiet command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+
+    def test_quiet_flag_short_form(self):
+        """Test -q flag suppresses output."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "examples/simple-project",
+                    "-q",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=".",
+            )
+
+            # Should exit with code 0 (success)
+            assert result.returncode == 0
+
+            # Should have no stdout output when quiet
+            assert result.stdout.strip() == ""
+
+            # Should not have stderr output for normal operation
+            assert result.stderr == ""
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("-q command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+
+    def test_normal_output_without_quiet(self):
+        """Test that normal output works when --quiet is not used."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "examples/simple-project",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=".",
+            )
+
+            # Should exit with code 0 (success)
+            assert result.returncode == 0
+
+            # Should have stdout output when not quiet
+            assert len(result.stdout.strip()) > 0
+            assert "Generating initial diagram..." in result.stdout
+            assert "Diagram generated and saved" in result.stdout
+
+            # Should not have stderr output for normal operation
+            assert result.stderr == ""
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("normal output command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")
+
+    def test_quiet_flag_still_shows_errors(self):
+        """Test that --quiet still shows errors on stderr."""
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mvn_tree_visualizer",
+                    "nonexistent_directory",
+                    "--quiet",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=".",
+            )
+
+            # Should exit with non-zero code (error)
+            assert result.returncode != 0
+
+            # Should have no stdout output when quiet (even with errors)
+            assert result.stdout.strip() == ""
+
+            # Should have stderr output for errors even when quiet
+            assert len(result.stderr.strip()) > 0
+            assert "ERROR:" in result.stderr
+
+        except subprocess.TimeoutExpired:
+            pytest.fail("--quiet error test command timed out")
+        except FileNotFoundError:
+            pytest.skip("mvn_tree_visualizer module not available for subprocess testing")

--- a/tests/test_watch_mode.py
+++ b/tests/test_watch_mode.py
@@ -1,7 +1,10 @@
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from mvn_tree_visualizer.cli import generate_diagram
+from mvn_tree_visualizer.exceptions import DependencyFileNotFoundError, DependencyParsingError
 from mvn_tree_visualizer.file_watcher import DependencyFileHandler
 
 
@@ -90,19 +93,18 @@ def test_generate_diagram_error_handling():
         # Try to generate diagram with non-existent file
         output_file = Path(temp_dir) / "test.html"
 
-        # This should not raise an exception, but should print an error
-        # and NOT create an output file (improved error handling)
-        generate_diagram(
-            directory=temp_dir,
-            output_file=str(output_file),
-            filename="non_existent_file",
-            keep_tree=False,
-            output_format="html",
-            show_versions=False,
-        )
+        # This should raise a DependencyFileNotFoundError
+        with pytest.raises(DependencyFileNotFoundError, match="No 'non_existent_file' files found"):
+            generate_diagram(
+                directory=temp_dir,
+                output_file=str(output_file),
+                filename="non_existent_file",
+                keep_tree=False,
+                output_format="html",
+                show_versions=False,
+            )
 
-        # With improved error handling, no output file should be created
-        # when there are no dependency files to process
+        # No output file should be created when there are errors
         assert not output_file.exists()
 
 
@@ -112,14 +114,15 @@ def test_generate_diagram_invalid_directory():
         output_file = Path(temp_dir) / "test.html"
 
         # Test with non-existent directory
-        generate_diagram(
-            directory="non_existent_directory",
-            output_file=str(output_file),
-            filename="maven_dependency_file",
-            keep_tree=False,
-            output_format="html",
-            show_versions=False,
-        )
+        with pytest.raises(DependencyFileNotFoundError, match="Directory 'non_existent_directory' does not exist"):
+            generate_diagram(
+                directory="non_existent_directory",
+                output_file=str(output_file),
+                filename="maven_dependency_file",
+                keep_tree=False,
+                output_format="html",
+                show_versions=False,
+            )
 
         # Should not create output file when directory doesn't exist
         assert not output_file.exists()
@@ -134,14 +137,17 @@ def test_generate_diagram_empty_dependency_file():
 
         output_file = Path(temp_dir) / "test.html"
 
-        generate_diagram(
-            directory=temp_dir,
-            output_file=str(output_file),
-            filename="maven_dependency_file",
-            keep_tree=False,
-            output_format="html",
-            show_versions=False,
-        )
+        # Empty files are treated as files with no content, so merge_files will skip them
+        # and find no files with actual content
+        with pytest.raises(DependencyParsingError, match="Error reading dependency file"):
+            generate_diagram(
+                directory=temp_dir,
+                output_file=str(output_file),
+                filename="maven_dependency_file",
+                keep_tree=False,
+                output_format="html",
+                show_versions=False,
+            )
 
         # Should not create output file when dependency file is empty
         assert not output_file.exists()
@@ -156,14 +162,16 @@ def test_generate_diagram_whitespace_only_dependency_file():
 
         output_file = Path(temp_dir) / "test.html"
 
-        generate_diagram(
-            directory=temp_dir,
-            output_file=str(output_file),
-            filename="maven_dependency_file",
-            keep_tree=False,
-            output_format="html",
-            show_versions=False,
-        )
+        # Whitespace-only files are treated as empty files with no content
+        with pytest.raises(DependencyParsingError, match="Error reading dependency file"):
+            generate_diagram(
+                directory=temp_dir,
+                output_file=str(output_file),
+                filename="maven_dependency_file",
+                keep_tree=False,
+                output_format="html",
+                show_versions=False,
+            )
 
         # Should not create output file when dependency file contains only whitespace
         assert not output_file.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -284,6 +284,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -373,6 +385,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -551,6 +572,7 @@ dependencies = [
 dev = [
     { name = "build" },
     { name = "git-changelog" },
+    { name = "pytest" },
     { name = "python-semantic-release" },
     { name = "tox" },
     { name = "twine" },
@@ -566,6 +588,7 @@ requires-dist = [
 dev = [
     { name = "build", specifier = ">=1.0.0" },
     { name = "git-changelog", specifier = ">=2.5.3" },
+    { name = "pytest", specifier = ">=8.4.1" },
     { name = "python-semantic-release", specifier = ">=10.2.0" },
     { name = "tox", specifier = ">=4.28.4" },
     { name = "twine", specifier = ">=6.1.0" },
@@ -769,6 +792,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🚀 Features Added

This PR introduces two essential CLI features that enhance usability and automation capabilities:

### ✅ Version Flag (`--version`, `-v`)
- **Purpose**: Display current tool version and exit
- **Usage**: `mvn-tree-visualizer --version` or `mvn-tree-visualizer -v`
- **Benefits**: Essential for automation scripts, debugging, and user support

### 🔇 Quiet Flag (`--quiet`, `-q`)  
- **Purpose**: Suppress all console output except errors
- **Usage**: `mvn-tree-visualizer --quiet [options]` or `mvn-tree-visualizer -q [options]`
- **Benefits**: Perfect for CI/CD pipelines, scripted usage, and automated builds

## 🧪 Testing

- ✅ **11 new CLI tests** covering both version and quiet flag functionality
- ✅ **All 56 tests passing** (100% test suite success)
- ✅ **Subprocess testing** for real CLI behavior validation
- ✅ **Error handling** comprehensive coverage
- ✅ **Cross-platform compatibility** (Windows encoding fixes included)

## 🔧 Technical Improvements

### Architecture Enhancements:
- **Better separation of concerns**: `generate_diagram()` raises exceptions, `cli()` handles exits
- **Improved error handling**: Proper exit codes (1 for errors, 130 for SIGINT)
- **Exception propagation**: More testable and maintainable code structure

### Compatibility Fixes:
- **Windows Unicode support**: Replaced Unicode emojis with ASCII for cp1252 compatibility
- **Backward compatibility**: All existing functionality preserved
- **Watch mode integration**: Both flags work seamlessly with file watching

## 📚 Documentation Updates

- Updated `README.md` with new CLI options table
- Added usage examples for both flags
- Comprehensive inline code documentation